### PR TITLE
Migrated Vagrant Box to ubuntu/trusty64 and changed DHCPD to use defaults

### DIFF
--- a/aeon_ztp/api/models.py
+++ b/aeon_ztp/api/models.py
@@ -25,4 +25,5 @@ class DeviceSchema(ma.ModelSchema):
     class Meta:
         model = Device
 
+
 device_schema = DeviceSchema()

--- a/aeon_ztp/config.py
+++ b/aeon_ztp/config.py
@@ -34,6 +34,7 @@ class TestingConfig(Config):
     TESTING = True
     SQLALCHEMY_DATABASE_URI = 'sqlite://'
 
+
 config = {
     "production": ProductionConfig,
     "testing": TestingConfig,

--- a/install/Vagrantfile
+++ b/install/Vagrantfile
@@ -1,8 +1,8 @@
 varsInterfaces = YAML.load_file("vars/interfaces.yml")
-ipAddr = varsInterfaces['Interfaces']['eth1']['address'].split('/')[0]
+ipAddr = varsInterfaces['interfaces']['eth1']['address'].split('/')[0]
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "cloudtoad/xenial_server_base"
+  config.vm.box = "ubuntu/trusty64"
   config.vm.hostname = 'aeon-ztps'
   config.vm.network "private_network", ip: ipAddr, nic_type: "virtio"
 

--- a/install/roles/dhcp-server/defaults/main.yml
+++ b/install/roles/dhcp-server/defaults/main.yml
@@ -1,10 +1,10 @@
 ---
 silly_cidr: "{{ ansible_eth1['ipv4']['network'] }}/{{ ansible_eth1['ipv4']['netmask'] }}"
 dhcp_cidr: "{{ silly_cidr | ipaddr('net') }}"
-dhcp_subnet: "{{ ansible_eth1['ipv4']['network'] }}"
-dhcp_netmask: "{{ ansible_eth1['ipv4']['netmask'] }}"
+dhcp_subnet: "{{ dhcp_cidr | ipaddr('network') }}"
+dhcp_netmask: "{{ dhcp_cidr | ipaddr('netmask') }}"
 dhcp_gateway: "{{ interfaces['eth1']['gateway'] }}"
-dhcp_address: "{{ ansible_eth1['ipv4']['address'] }}"
+dhcp_address: "{{ dhcp_cidr | ipaddr('address') }}"
 dhcp_lease_start: "{{ dhcp_cidr | ipaddr('10') | ipaddr('address')}}"
 dhcp_lease_end: "{{ dhcp_cidr | ipaddr('-10') |ipaddr('address') }}"
 dhcp_nameserver: "{{ ansible_dns['nameservers'][0] }}"

--- a/install/roles/dhcp-server/defaults/main.yml
+++ b/install/roles/dhcp-server/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+silly_cidr: "{{ ansible_eth1['ipv4']['network'] }}/{{ ansible_eth1['ipv4']['netmask'] }}"
+dhcp_cidr: "{{ silly_cidr | ipaddr('net') }}"
+dhcp_subnet: "{{ ansible_eth1['ipv4']['network'] }}"
+dhcp_netmask: "{{ ansible_eth1['ipv4']['netmask'] }}"
+dhcp_gateway: "{{ interfaces['eth1']['gateway'] }}"
+dhcp_address: "{{ ansible_eth1['ipv4']['address'] }}"
+dhcp_lease_start: "{{ dhcp_cidr | ipaddr('10') | ipaddr('address')}}"
+dhcp_lease_end: "{{ dhcp_cidr | ipaddr('-10') |ipaddr('address') }}"
+dhcp_nameserver: "{{ ansible_dns['nameservers'][0] }}"

--- a/install/roles/dhcp-server/defaults/main.yml
+++ b/install/roles/dhcp-server/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
-silly_cidr: "{{ ansible_eth1['ipv4']['network'] }}/{{ ansible_eth1['ipv4']['netmask'] }}"
-dhcp_cidr: "{{ silly_cidr | ipaddr('net') }}"
+dhcp_cidr: "{{ interfaces['eth1']['address'] }}"
 dhcp_subnet: "{{ dhcp_cidr | ipaddr('network') }}"
 dhcp_netmask: "{{ dhcp_cidr | ipaddr('netmask') }}"
 dhcp_gateway: "{{ interfaces['eth1']['gateway'] }}"

--- a/install/roles/dhcp-server/tasks/main.yml
+++ b/install/roles/dhcp-server/tasks/main.yml
@@ -1,4 +1,3 @@
-# --------------------------------------------------------
 - include_vars: "{{ playbook_dir }}/vars/dhcp-server.yml"
 
 - name: install ISC DHCP server

--- a/install/roles/dhcp-server/tasks/main.yml
+++ b/install/roles/dhcp-server/tasks/main.yml
@@ -14,4 +14,6 @@
   service: name=isc-dhcp-server enabled=yes state=started
   when: DHCPS_enable == True
 
-
+- name: Disable / stop DHCP service
+  service: name=isc-dhcp-server enabled=no state=stopped
+  when: DHCPS_enable == False

--- a/install/roles/dhcp-server/templates/dhcpd.conf
+++ b/install/roles/dhcp-server/templates/dhcpd.conf
@@ -4,10 +4,6 @@
 # behavior of the version 2 packages ('none', since DHCP v2 didn't
 # have support for DDNS.)
 
-{% set server_ip_prefix = Interfaces[DHCPS_config.interface].address %}
-{% set server_ipaddr = server_ip_prefix | ipaddr('address') %}
-{% set server_gateway = Interfaces[DHCPS_config.interface].gateway | default(None) %}
-
 ddns-update-style none;
 
 default-lease-time 7200;
@@ -22,11 +18,11 @@ option cumulus-provision-url code 239 = text;
 # this default-url *MUST* be in the global area for ONIE to
 # work properly.  Not sure why this is, but it is.
 
-option default-url = "http://{{ server_ipaddr }}:8080/images/cumulus/onie-installer";
+option default-url = "http://{{ dhcp_address }}:8080/images/cumulus/onie-installer";
 
 class "cumulus-switch" {
    match if (substring(option host-name, 0, 7) = "cumulus");
-   option cumulus-provision-url "http://{{ server_ipaddr }}:8080/downloads/ztp-cumulus.sh";
+   option cumulus-provision-url "http://{{ dhcp_address }}:8080/downloads/ztp-cumulus.sh";
 }
 
 class "eos-switch" {
@@ -39,16 +35,14 @@ class "nxos-switch" {
    option bootfile-name "ztp-nxos.py";
 }
 
-{% set subnet = server_ip_prefix | ipaddr('network') %}
-{% set netmask = server_ip_prefix | ipaddr('netmask') %}
 
-subnet {{ subnet }} netmask {{ netmask }} {
-   range {{ DHCPS_config.lease[0] }} {{ DHCPS_config.lease[1] }};
-   option tftp-server-name "{{ server_ipaddr }}";
-{% if server_gateway  %}
-   option routers {{ server_gateway }};
+subnet {{ dhcp_subnet }} netmask {{ dhcp_netmask }} {
+   range {{ dhcp_lease_start }} {{ dhcp_lease_end }};
+   option tftp-server-name "{{ dhcp_address }}";
+{% if dhcp_gateway  %}
+   option routers {{ dhcp_gateway }};
 {% endif %}
-{% if DHCPS_config.nameserver is defined %}
-   option domain-name-servers {{ DHCPS_config.nameserver }};
+{% if dhcp_nameserver is defined %}
+   option domain-name-servers {{ dhcp_nameserver }};
 {% endif %}
 }

--- a/install/roles/ubuntu-base/tasks/interfaces.yml
+++ b/install/roles/ubuntu-base/tasks/interfaces.yml
@@ -1,6 +1,12 @@
 - name: install /etc/network/interfaces
   copy: src=interfaces dest=/etc/network/interfaces
 
-- name: create interface cfg files
+- name: create vagrant interface cfg files
   template: src=iface.jinja2 dest=/etc/network/interfaces.d/{{ item.key }}.cfg
   with_dict: "{{ interfaces }}"
+  when: packer is not defined or not packer
+
+- name: create packer interface cfg files
+  template: src=iface.jinja2 dest=/etc/network/interfaces.d/{{ item.key }}.cfg
+  with_dict: "{{ packer_interfaces }}"
+  when: packer is defined and packer

--- a/install/roles/ubuntu-base/tasks/interfaces.yml
+++ b/install/roles/ubuntu-base/tasks/interfaces.yml
@@ -3,4 +3,4 @@
 
 - name: create interface cfg files
   template: src=iface.jinja2 dest=/etc/network/interfaces.d/{{ item.key }}.cfg
-  with_dict: "{{ Interfaces }}"
+  with_dict: "{{ interfaces }}"

--- a/install/roles/ubuntu-base/tasks/main.yml
+++ b/install/roles/ubuntu-base/tasks/main.yml
@@ -5,7 +5,10 @@
   command: sed  -ie 's/^\(127.0[^ \t]*\)[ \t]*ubuntu$/\1\t{{ Hostname }}/g' /etc/hosts
   ignore_errors: true
 
+- name: Update apt
+  apt:
+    update_cache: yes
+
 - include: users.yml
-- include: apt_update.yml
 - include: software.yml
 - include: interfaces.yml

--- a/install/roles/ubuntu-base/templates/iface.jinja2
+++ b/install/roles/ubuntu-base/templates/iface.jinja2
@@ -12,5 +12,8 @@ iface {{ item.key }} inet static
 {% endif %}
 {% if item.value.metric is defined %}
     metric {{ item.value.metric }}
+{% if item.value.dns_nameservers is defined %}
+    dns-nameservers {{ item.value.dns_nameservers }}
+{% endif %}
 {% endif %}
 {% endif %}

--- a/install/vars/dhcp-server.yml
+++ b/install/vars/dhcp-server.yml
@@ -1,6 +1,11 @@
-DHCPS_enable: no
+DHCPS_enable: False
 
-DHCPS_config:
-    interface: eth1
-    lease: [192.168.59.50, 192.168.59.150]
-    nameserver: 192.168.59.254
+# Uncomment and add values to override defaults defined in dhcp-server role
+# dhcp_cidr: dhcp_cidr
+# dhcp_subnet: "{{ ansible_eth1['ipv4']['network'] }}"
+# dhcp_netmask: "{{ ansible_eth1['ipv4']['netmask'] }}"
+# dhcp_gateway: "{{ interfaces['eth1']['gateway'] }}"
+# dhcp_address: "{{ ansible_eth1['ipv4']['address'] }}"
+# dhcp_lease_start: "{{ dhcp_cidr | ipaddr('10') | ipaddr('address')}}"
+# dhcp_lease_end: "{{ dhcp_cidr | ipaddr('-10') |ipaddr('address') }}"
+# dhcp_nameserver: "{{ ansible_dns['nameservers'][0] }}"

--- a/install/vars/dhcp-server.yml
+++ b/install/vars/dhcp-server.yml
@@ -1,11 +1,12 @@
 DHCPS_enable: False
 
 # Uncomment and add values to override defaults defined in dhcp-server role
+
 # dhcp_cidr: dhcp_cidr
-# dhcp_subnet: "{{ ansible_eth1['ipv4']['network'] }}"
-# dhcp_netmask: "{{ ansible_eth1['ipv4']['netmask'] }}"
+# dhcp_subnet: "{{ dhcp_cidr | ipaddr('network') }}"
+# dhcp_netmask: "{{ dhcp_cidr | ipaddr('netmask') }}"
 # dhcp_gateway: "{{ interfaces['eth1']['gateway'] }}"
-# dhcp_address: "{{ ansible_eth1['ipv4']['address'] }}"
+# dhcp_address: "{{ dhcp_cidr | ipaddr('address') }}"
 # dhcp_lease_start: "{{ dhcp_cidr | ipaddr('10') | ipaddr('address')}}"
 # dhcp_lease_end: "{{ dhcp_cidr | ipaddr('-10') |ipaddr('address') }}"
 # dhcp_nameserver: "{{ ansible_dns['nameservers'][0] }}"

--- a/install/vars/interfaces.yml
+++ b/install/vars/interfaces.yml
@@ -1,4 +1,4 @@
-Interfaces:
+interfaces:
     eth0:
         dhcp: true
     eth1:

--- a/install/vars/interfaces.yml
+++ b/install/vars/interfaces.yml
@@ -5,3 +5,10 @@ interfaces:
         address: 192.168.59.254/24
         gateway: 192.168.59.3
         metric: 10
+
+packer_interfaces:
+    eth0:
+        address: 192.168.59.254/24
+        gateway: 192.168.59.3
+        metric: 10
+        dns_nameservers: 8.8.8.8

--- a/install/via-ansible.yml
+++ b/install/via-ansible.yml
@@ -1,12 +1,14 @@
 ---
 - hosts: all
   become: true
+  gather_facts: true
   vars:
     - TopDir: "{{ playbook_dir }}/.."
 
   vars_files:
     - vars/host.yml
     - vars/interfaces.yml
+    - vars/dhcp-server.yml
 
   roles:
     - ubuntu-base
@@ -21,3 +23,4 @@
       async: 1
       poll: 0
       ignore_errors: true
+      when: packer is defined and not packer

--- a/install/via-ansible.yml
+++ b/install/via-ansible.yml
@@ -23,4 +23,4 @@
       async: 1
       poll: 0
       ignore_errors: true
-      when: packer is defined and not packer
+      when: (packer is defined and not packer) or (packer is not defined)


### PR DESCRIPTION
- Vagrant no longer using bespoke box file.
- New file does not require any package manager hacking.
- DHCP addressing logic moved out of jinja template and into defaults file
- DHCP defaults can be overridden by commenting out vars/dhcp-server.yml