### PR TITLE
Safely write to md5 cache file

### DIFF
--- a/aeon_ztp/bin/eos_bootstrap.py
+++ b/aeon_ztp/bin/eos_bootstrap.py
@@ -7,6 +7,7 @@ import argparse
 import subprocess
 import logging
 import logging.handlers
+import tempfile
 import time
 import requests
 import hashlib
@@ -295,8 +296,11 @@ class EosBootstrap(object):
         with open(filepath, 'rb') as f:
             md5sum = hashlib.md5(f.read()).hexdigest()
 
-        with open(md5sum_fpath, 'a') as f:
-            f.write(md5sum)
+        with tempfile.NamedTemporaryFile('w', dir=os.path.dirname(md5sum_fpath), delete=False) as tf:
+            tf.write(md5sum)
+            tempname = tf.name
+
+        os.rename(tempname, md5sum_fpath)
 
         return md5sum
 

--- a/aeon_ztp/bin/nxos_bootstrap.py
+++ b/aeon_ztp/bin/nxos_bootstrap.py
@@ -8,6 +8,7 @@ import argparse
 import subprocess
 import logging
 import logging.handlers
+import tempfile
 import time
 import requests
 from retrying import retry
@@ -295,8 +296,11 @@ class NxosBootstrap(object):
         with open(filepath, 'rb') as f:
             md5sum = hashlib.md5(f.read()).hexdigest()
 
-        with open(md5sum_fpath, 'a') as f:
-            f.write(md5sum)
+        with tempfile.NamedTemporaryFile('w', dir=os.path.dirname(md5sum_fpath), delete=False) as tf:
+            tf.write(md5sum)
+            tempname = tf.name
+
+        os.rename(tempname, md5sum_fpath)
 
         return md5sum
 


### PR DESCRIPTION
The currently used technique with appending to file could lead
to md5 sum being written twice into the file in case two devices
are being bootstrapped simultaneously. Which actually happend in my
case when I've tried that with a couple Arista switches.

Replaced that code with write-replace pattern, which is a safe way to
do the same thing. For details see that blog post:
https://blog.gocept.com/2013/07/15/reliable-file-updates-with-python/