### PR TITLE
Add a regex to match newer DHCP messages and also make it backward compatible

### DIFF
--- a/ztp-scripts/ztp-eos.sh
+++ b/ztp-scripts/ztp-eos.sh
@@ -28,7 +28,7 @@ SERVER_PORT=8080
 # of the Aeon ZTP server
 # ----------------------------------------------------
 
-DHCP_SUCCESS=$(grep -m1 DHCP_SUCCESS /var/log/messages)
+DHCP_SUCCESS=$(grep -m1 DHCP.*_SUCCESS /var/log/messages)
 NAME_SERVER=$(grep -m1 nameserver /var/log/messages)
 
 # example output:


### PR DESCRIPTION
    Looks like we now have support for v6 dhcp as well. So the message is contains the string v4 and we were grepping only for DHCP_SUCCESS