### PR TITLE
[EOS] Download image before installation

### DIFF
--- a/aeon_ztp/bin/eos_bootstrap.py
+++ b/aeon_ztp/bin/eos_bootstrap.py
@@ -379,12 +379,11 @@ class EosBootstrap(object):
             self.dev.api.configure(['boot system flash:%s' % self.image_name])
 
         else:
-            # Install directly from ZTPS, bypassing the need to copy first
-            # Note that even if the install fails, this image will persist in flash.
-            # The next retry attempt will not have to download the image again.
-            cmds = ['install source http://{server}/images/{OS}/{filename}'
-                    .format(server=self.server, OS=self.os_name,
-                            filename=self.image_name)]
+            delete_img_cmd = 'bash timeout 45 rm -f /mnt/flash/%s' % self.image_name
+            copy_img_cmd = 'copy http://{server}/images/{OS}/{filename} flash:'.format(
+                server=self.server, OS=self.os_name, filename=self.image_name)
+            install_img_cmd = 'install source flash:%s' % self.image_name
+            cmds = [delete_img_cmd, copy_img_cmd, install_img_cmd]
             try:
                 self.dev.api.execute(cmds)
             except CommandError as e:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
-pytest>=3.0.1
+pytest==3.6.3
 Flask-Testing==0.5.0
 mock==2.0
 flake8>=3.0.0
+


### PR DESCRIPTION
On Arista EOS, do not rely on 'install source' command via HTTP, because it can keep management connectivity busy for a long time thus causing the eapi channel to break and leave the box in unknown state.

Instead, download the file locally to bootflash and run installation from there. 