### PR TITLE
#243 Increase uwsgi_temp_file_size to accomodate images upto 5G

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 pytest==3.6.3
 Flask-Testing==0.5.0
 mock==2.0
-flake8>=3.0.0
+flake8==3.5.0
 

--- a/install/roles/web-server/files/nginx.aeon-ztp.ini
+++ b/install/roles/web-server/files/nginx.aeon-ztp.ini
@@ -9,6 +9,7 @@ server {
     location / {
         include uwsgi_params;
         uwsgi_pass unix:/tmp/aeon-ztp.sock;
+        uwsgi_max_temp_file_size 5120;
     }
 
     location ~ /help/?(.*)$ {

--- a/install/roles/web-server/files/nginx.aeon-ztp.ini
+++ b/install/roles/web-server/files/nginx.aeon-ztp.ini
@@ -5,11 +5,11 @@ server {
     listen 80;
     listen 8080;
     server_name localhost aeon-ztp;
+    uwsgi_max_temp_file_size 5120;
 
     location / {
         include uwsgi_params;
         uwsgi_pass unix:/tmp/aeon-ztp.sock;
-        uwsgi_max_temp_file_size 5120;
     }
 
     location ~ /help/?(.*)$ {

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ ansible==2.3.1.0
 Pygments==2.1.3
 python-magic==0.4.12
 isc-dhcp-leases==0.8.1
-requests==2.17.3
+requests==2.21.0
 PyYAML==3.11
 Flask==0.11.1
 Flask-Script==2.0.5
@@ -24,3 +24,4 @@ paramiko==2.4.1
 aeon-venos[nxos,cumulus,ubuntu,eos,centos]>=0.9.16
 flask-moment==0.5.2
 Flask-Migrate==2.1.1
+flake8==3.5.0


### PR DESCRIPTION
When buffering of responses from the uwsgi server is enabled, and the whole response does not fit into the buffers set by the uwsgi_buffer_size and uwsgi_buffers directives, a part of the response can be saved to a temporary file. This directive sets the maximum size of the temporary file.