### PR TITLE
Add placeholders for few other platforms to simplify deploy

### DIFF
--- a/etc/profiles/centos/os-selector.cfg
+++ b/etc/profiles/centos/os-selector.cfg
@@ -1,0 +1,8 @@
+#
+# 'default' means match hardware models not explicitly configured
+# See eos/os-selector.cfg or documentation for full details on the syntax and
+# semantics of this file
+#
+default:
+  exact_match: ".*"
+  finally: finally

--- a/etc/profiles/opx/os-selector.cfg
+++ b/etc/profiles/opx/os-selector.cfg
@@ -1,0 +1,8 @@
+#
+# 'default' means match hardware models not explicitly configured
+# See eos/os-selector.cfg or documentation for full details on the syntax and
+# semantics of this file
+#
+default:
+  exact_match: ".*"
+  finally: finally

--- a/etc/profiles/ubuntu/os-selector.cfg
+++ b/etc/profiles/ubuntu/os-selector.cfg
@@ -1,0 +1,8 @@
+#
+# 'default' means match hardware models not explicitly configured
+# See eos/os-selector.cfg or documentation for full details on the syntax and
+# semantics of this file
+#
+default:
+  exact_match: ".*"
+  finally: finally


### PR DESCRIPTION
We need this as part of refactoring we are doing to remove embedded
aos-di from the AOS ztp appliance. These additional platforms existed in
aos-di repo..