### PR TITLE
Fix permissions to make sure os-selector and other config files are editable by admin user

### DIFF
--- a/install/roles/aeon-ztp-server/tasks/main.yml
+++ b/install/roles/aeon-ztp-server/tasks/main.yml
@@ -22,7 +22,7 @@
 - name: copy aeon-ztps directories over
   copy: src="{{ TopDir }}/{{ item }}" dest={{ Install_dir }}
         owner={{ Aeon_user }} group={{ Aeon_group }}
-        directory_mode=775
+        directory_mode=775 mode=776
   with_items:
     - aeon_ztp/bin
     - etc


### PR DESCRIPTION
Previously only directories had right permission and the file
permissions were set by some other internal playbook - but this playbook
is the right place for perms on ztp related files..