### PR TITLE
Serve static NOS images directly from nginx instead of uwsgi app

### DIFF
--- a/aeon_ztp/api/views.py
+++ b/aeon_ztp/api/views.py
@@ -30,12 +30,6 @@ def download_file(filename):
     return send_from_directory(from_dir, filename)
 
 
-@api.route('/images/<path:filename>', methods=['GET'])
-def get_vendor_file(filename):
-    from_dir = path.join(_AEON_TOPDIR, 'vendor_images')
-    return send_from_directory(from_dir, filename)
-
-
 @api.route('/api/about')
 def api_version():
     version = pkg_resources.get_distribution("aeon_ztp").version

--- a/install/roles/web-server/files/nginx.aeon-ztp.ini
+++ b/install/roles/web-server/files/nginx.aeon-ztp.ini
@@ -16,8 +16,8 @@ server {
         autoindex on;
         gzip on;
         gzip_comp_level 5;
-        gzip_http_version 1.1;
         gzip_min_length 256;
+        gzip_types *;
         alias   /opt/aeonztps/vendor_images/$1;
     }
 

--- a/install/roles/web-server/files/nginx.aeon-ztp.ini
+++ b/install/roles/web-server/files/nginx.aeon-ztp.ini
@@ -12,6 +12,15 @@ server {
         uwsgi_pass unix:/tmp/aeon-ztp.sock;
     }
 
+    location /images/ {
+        autoindex on;
+        gzip on;
+        gzip_comp_level 5;
+        gzip_http_version 1.1;
+        gzip_min_length 256;
+        alias   /opt/aeonztps/vendor_images/$1;
+    }
+
     location ~ /help/?(.*)$ {
          alias /opt/aeonztps/docs/_build/html/$1;
     }

--- a/tests/test_aeon_ztp_api.py
+++ b/tests/test_aeon_ztp_api.py
@@ -54,18 +54,6 @@ def test_download_file(client):
     assert rv.data == 'test_data_stream'
 
 
-def test_get_vendor_file(client):
-    vendor_dir = os.path.join(os.environ['AEON_TOPDIR'], 'vendor_images')
-    temp = NamedTemporaryFile(dir=vendor_dir)
-    temp.write('test_data_stream')
-    try:
-        rv = client.get("/images/" + os.path.basename(temp.name))
-    finally:
-        temp.close()
-    assert rv.status_code == 200
-    assert rv.data == 'test_data_stream'
-
-
 def test_api_version(client):
     try:
         expected_version = pkg_resources.get_distribution('aeon-ztp').version


### PR DESCRIPTION
Hi,

submitting this PR to fix a limitation of current Aeon ZTP implementation where HTTP requests to get NOS images (e.g. Cisco NXOS) are forced to go via the uwsgi app. This can cause severe limitations when multiple/concurrent requests need to be served, for instance in a topology with 3+ doing POAP/ZTP at the same time, thus pulling the vendor images concurrently.

We could reproduce the issue by uploading a vendor image (e.g. nxos_9.2.2.bin) under /opt/aeonztps/vendor_images/nxos and issue concurrent wgets to Aeon ZTP webserver trying to pull the same image.

Before this fix, you could get at most 2 concurrent connections while the remaining connections are stuck in connected state, but not data is transferred. This caused a severe issue with uwsgi app, stuck for several seconds/minutes until nginx can starts returning 504 Gateway Timeouts. This can cause issues with undergoing ZTP processes on the devices.

With this fix, multiple concurrent connections can be opened (of course bandwidth is divided among the connections) and, more importantly, uswgi app is freed from the burden of service large static files and able to serve remaining REST API calls. 