### PR TITLE
[AOS-12479] Fx pass env variables to bootstrap script

### DIFF
--- a/aeon_ztp/ztp_celery.py
+++ b/aeon_ztp/ztp_celery.py
@@ -163,7 +163,7 @@ def do_bootstrapper(server, os_name, target, log):
     # must pass command as a single string; using shell=True
 
     this = subprocess.Popen(
-        cmd_str, shell=True,
+        cmd_str, shell=True, env=os.environ.copy(),
         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     log.info("starting bootstrapper[pid={pid}] [{cmd_str}]".format(


### PR DESCRIPTION
We found a bug where bootstrapper script failed to login when  using non-default credentials in /etc/aeonztp.conf. 

I have validated it manually but unfortunately I haven't found a good unittest for this, and it seems existing test validates that env variables are specified via command line args but not their values are actually set (also, Popen is just mocked where needed). If you have a better suggestion please advice.

Thanks!