### PR TITLE
add boot drive support for eos bootstrap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+python:
+    - "2.7"
 install:
   - pip install tox coveralls pytest
 script:

--- a/aeon_ztp/bin/aztp_os_selector.py
+++ b/aeon_ztp/bin/aztp_os_selector.py
@@ -160,6 +160,7 @@ def main():
             dev_data = json.loads(cli_args.json)
             hw_match = match_hw_model(dev_data, cfg_data)
             sw_match = match_os_version(dev_data, hw_match.data)
+            boot_drives = hw_match.data.get('boot_drives')
             finally_script = hw_match.data.get('finally')
 
         except ValueError:
@@ -200,6 +201,7 @@ def main():
     exit_results({
         'ok': True,
         'image_name': sw_match,
+        'boot_drives': boot_drives,
         'finally': finally_script
     })
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ aeon-venos[nxos,cumulus,ubuntu,eos,centos]>=0.9.16
 flask-moment==0.5.2
 Flask-Migrate==2.1.1
 flake8==3.5.0
+urllib3==1.24.3

--- a/tests/test_aztp_os_selector.py
+++ b/tests/test_aztp_os_selector.py
@@ -318,4 +318,30 @@ def test_main(mock_cli_parse, mock_load_cfg, mock_json_load, mock_exit_results, 
     mock_cli_parse.return_value = cli_args
     with pytest.raises(SystemExit):
         aztp_os_selector.main()
-    mock_exit_results.assert_called_with({'ok': True, 'image_name': sw_match, 'finally': hw_match.data['finally']})
+    mock_exit_results.assert_called_with({'ok': True, 'image_name': sw_match,
+                                          'boot_drives': None,
+                                          'finally': hw_match.data['finally']})
+
+
+@patch('aeon_ztp.bin.aztp_os_selector.match_os_version')
+@patch('aeon_ztp.bin.aztp_os_selector.match_hw_model')
+@patch('aeon_ztp.bin.aztp_os_selector.exit_results', side_effect=SystemExit)
+@patch('aeon_ztp.bin.aztp_os_selector.json.loads')
+@patch('aeon_ztp.bin.aztp_os_selector.load_cfg', return_value=cfg_data)
+@patch('aeon_ztp.bin.aztp_os_selector.cli_parse')
+def test_main_with_boot_drives(mock_cli_parse, mock_load_cfg, mock_json_load, mock_exit_results, mock_hw_match,
+              mock_os_match, cli_args):
+    sw_match = '4.21.5F'
+    item_match = namedtuple('item_match', ['hw_match', 'data'])
+    hw_match = item_match(hw_match='default', data={'image': 'Eos.swi',
+                                                    'exact_match': '4.21.5F',
+                                                    'boot_drives': ['drive1', 'usb1', 'flash'],
+                                                    'finally': 'finally'})
+    mock_hw_match.return_value = hw_match
+    mock_os_match.return_value = sw_match
+    mock_cli_parse.return_value = cli_args
+    with pytest.raises(SystemExit):
+        aztp_os_selector.main()
+    mock_exit_results.assert_called_with({'ok': True, 'image_name': sw_match,
+                                          'boot_drives': ['drive1', 'usb1', 'flash'],
+                                          'finally': hw_match.data['finally']})


### PR DESCRIPTION
introduce boot-drives to eos os-selector, eos bootstrap will try os installation base on ordered sequence listed in boot-drives.

for example if boot-drives: ['drive1', 'flash'], eos.swi will be installed to drive1 if device has internal ssd disk, if not, fall back to flash disk.

